### PR TITLE
Correcting the name of the README

### DIFF
--- a/calpicker.gemspec
+++ b/calpicker.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = "an embeddable version of calendar_date_picker gem, using asset pipeline"
   s.description = "an embeddable version of calendar_date_picker gem, using asset pipeline."
 
-  s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
+  s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails", "~> 3.2.0"


### PR DESCRIPTION
This suppresses an annoying and ultimately null-content warning in Bundler.
